### PR TITLE
auto sync & publish upstream release

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,9 +1,8 @@
 name: Sync Fork
 
 on:
-    workflow_dispatch
-#   schedule:
-#     - cron: '0 0 */3 * *'  # runs at midnight every 3 days     
+  schedule:
+    - cron: '0 0 */3 * *'  # runs at midnight every 3 days     
 
 jobs:
   sync:
@@ -15,7 +14,7 @@ jobs:
         with:
           owner: SDSC-ORD
           base: master
-          head: rmfranken:master
+          head: TopQuadrant:master
           ignore_fail: true
           retries: 1
           retry_after: 15
@@ -27,7 +26,7 @@ jobs:
      - name: Checkout repository
        uses: actions/checkout@v3
        with:
-          repository: 'rmfranken/shacl-upstream'
+          repository: 'TopQuadrant/shacl'
           
      - name: Get Version Tag
        id: get_version_tag

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,58 @@
+name: Sync Fork
+
+on:
+    workflow_dispatch
+#   schedule:
+#     - cron: '0 0 */3 * *'  # runs at midnight every 3 days     
+
+jobs:
+  sync:
+    permissions: write-all
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: SDSC-ORD
+          base: master
+          head: rmfranken:master
+          ignore_fail: true
+          retries: 1
+          retry_after: 15
+  fetch-release:
+    permissions: write-all
+    runs-on: ubuntu-latest
+
+    steps:
+     - name: Checkout repository
+       uses: actions/checkout@v3
+       with:
+          repository: 'rmfranken/shacl-upstream'
+          
+     - name: Get Version Tag
+       id: get_version_tag
+       run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
+          
+          LATEST_RELEASE=$(git describe --abbrev=0 --tags )
+          echo "latest-release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
+          echo "$LATEST_RELEASE"
+    outputs:
+      tag: "${{ steps.get_version_tag.outputs.latest-release }}"   
+  
+          
+  publish:
+    needs: [fetch-release, sync] 
+    runs-on: ubuntu-latest
+    
+    steps:
+     - name: Checkout repository
+       uses: actions/checkout@v3
+             
+     - name: automated_release_with_tag
+       uses: "marvinpinto/action-automatic-releases@latest"
+       with:
+         repo_token: "${{ secrets.GITHUB_TOKEN }}"
+         prerelease: false
+         automatic_release_tag: "${{ needs.fetch-release.outputs.tag }}"

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -36,7 +36,6 @@ jobs:
           
           LATEST_RELEASE=$(git describe --abbrev=0 --tags )
           echo "latest-release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
-          echo "$LATEST_RELEASE"
     outputs:
       tag: "${{ steps.get_version_tag.outputs.latest-release }}"   
   
@@ -50,7 +49,7 @@ jobs:
        uses: actions/checkout@v3
              
      - name: automated_release_with_tag
-       uses: "marvinpinto/action-automatic-releases@latest"
+       uses: "marvinpinto/action-automatic-releases@v1.2.1"
        with:
          repo_token: "${{ secrets.GITHUB_TOKEN }}"
          prerelease: false


### PR DESCRIPTION
every 3 days, this gh actions script will look at the upstream repository (topQuadrant SHACL) and ingest its changes if there are any. If a new release has been done, it will also copy that and make a new release with the same version number.