### PR TITLE
Fix automated release action

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -49,8 +49,7 @@ jobs:
        uses: actions/checkout@v3
              
      - name: automated_release_with_tag
-       uses: "marvinpinto/action-automatic-releases@v1.2.1"
+       uses: "softprops/action-gh-release@v1"
        with:
-         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-         prerelease: false
-         automatic_release_tag: "${{ needs.fetch-release.outputs.tag }}"
+         token: "${{ secrets.GITHUB_TOKEN }}"
+         tag_name: "${{ needs.fetch-release.outputs.tag }}"


### PR DESCRIPTION
Current publish action uses deprecated commands, see warnings [here](https://github.com/SDSC-ORD/shacl/actions/runs/4570141691).

After a search in the action issues and PRs, it's clear that the action is not maintained anymore. Luckily users found and recommended a new action that is kept updated: https://github.com/marketplace/actions/gh-release.

This PR uses the new action and testing the action seems successful in the test repository without any warning, see [here](https://github.com/SDSC-ORD/shacl-downstream/actions/runs/4572330907).