### PR TITLE
Container size optimization

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11 as jre-build
+FROM eclipse-temurin:11-alpine as jre-build
 WORKDIR /app
 
 ARG VERSION
@@ -21,9 +21,7 @@ RUN $JAVA_HOME/bin/jlink \
          --compress=2 \
          --output /javaruntime
 
-RUN apt-get -y update && \
-    apt-get -y install maven curl zip && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add maven curl zip
 
 # Compile with maven, extract binaries and copy into image
 COPY . /app

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
I noticed that our container had a similar size to the `jena` container which is ~198MB and I found out that our ubuntu base image was the reason. With `alpine` we're down to ~87MB, making it more portable and quicker to pull and use.
