### PR TITLE
fix: base image for arm

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -85,5 +85,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.get_version.outputs.version_build }}
-            ARCH_BASE=amd64/eclipse-temurin:11-alpine
+            ARCH_BASE=amazoncorretto:11-alpine3.18-jdk
           outputs: type=image


### PR DESCRIPTION
After trying to run the Docker image on my Mac I realized I confused the name of the base image for `arm`.
`amd64` is an `x86` base image. I now found an `arm64` base image from `amazoncorretto` with which I was able to build and run the image locally 👍 