### PR TITLE
fix: multiarch Github action to have both x86 and arm64 images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            base: eclipse-temurin:11-alpine
+          - platform: linux/arm64
+            base: amazoncorretto:11-alpine3.18-jdk
 
     steps:
       - name: Checkout repository
@@ -62,28 +69,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
         # https://github.com/docker/build-push-action
-      - name: Build and push x86 Docker image
+      - name: Build and push Docker image for x86 and arm64
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
         with:
           file: .docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.get_version.outputs.version_build }}
-            ARCH_BASE=eclipse-temurin:11-alpine
-          outputs: type=image
-
-      - name: Build and push ARM Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
-        with:
-          file: .docker/Dockerfile
-          push: true
-          platforms: linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.get_version.outputs.version_build }}
-            ARCH_BASE=amazoncorretto:11-alpine3.18-jdk
+            ARCH_BASE=${{ matrix.base }}
           outputs: type=image


### PR DESCRIPTION
Our good old @rmfranken spotted a bug in the [validation GH action](https://github.com/SDSC-ORD/SDSC-IKG/actions/runs/6185538411/job/17002350854) causing the following error:
```
Unable to find image 'ghcr.io/sdsc-ord/shacl:latest' locally
latest: Pulling from sdsc-ord/shacl
docker: no matching manifest for linux/amd64 in the manifest list entries.
```
It looks like our current setup does not provide images for both `arm` and `x86`, instead the GitHub action overwrites the `x86` image with the `arm` one, which is the [only one available](https://github.com/SDSC-ORD/shacl/pkgs/container/shacl/125035530?tag=1.4.2_4602c17). After a bit of search I found out the correct approach to build multiarch images when we have different arguments involved: [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)! 
This PR implements the matrix approach to allow proper multiarch images for shacl.