### PR TITLE
Adding Docker manifest build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -70,6 +70,7 @@ jobs:
 
         # https://github.com/docker/build-push-action
       - name: Build and push Docker image for x86 and arm64
+        id: build
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
         with:
           file: .docker/Dockerfile
@@ -80,4 +81,59 @@ jobs:
           build-args: |
             VERSION=${{ steps.get_version.outputs.version_build }}
             ARCH_BASE=${{ matrix.base }}
-          outputs: type=image
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+        # https://github.com/actions/upload-artifact
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+      runs-on: ubuntu-latest
+      needs:
+        - build
+      steps:
+          # https://github.com/actions/download-artifact
+        - name: Download digests
+          uses: actions/download-artifact@v3
+          with:
+            name: digests
+            path: /tmp/digests
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+          # https://github.com/docker/metadata-action
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+                type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+                type=raw,value=${{ steps.get_version.outputs.version_build}},enable=${{ github.event_name == 'push' }}
+                type=raw,value=${{ steps.get_version.outputs.latest-release}},enable=${{ github.event_name == 'release' }}
+
+          # https://github.com/docker/login-action
+        - name: Log in to the Container registry
+          uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Create manifest list and push
+          working-directory: /tmp/digests
+          run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)          
+        - name: Inspect image
+          run: |
+            docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}          


### PR DESCRIPTION
This PR is based the [Docker docs](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) to divide builds into different runners and create a manifest to match each image to its corresponding OS.
Right now, the images for each platform are overwritten, resulting in no images for x86 architecture. Compared to gimie, SHACL images for different OSes require a different starting layer, meaning that the GitHub action is a bit more elaborate.